### PR TITLE
Add password strength tests

### DIFF
--- a/Downloads/cinematic-ai-chatbot(13)/.gitignore
+++ b/Downloads/cinematic-ai-chatbot(13)/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# test output
+/dist/

--- a/Downloads/cinematic-ai-chatbot(13)/__tests__/password-validation.test.ts
+++ b/Downloads/cinematic-ai-chatbot(13)/__tests__/password-validation.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { validatePasswordStrength } from '../lib/utils/password-validation';
+
+describe('validatePasswordStrength', () => {
+  it('returns strong score and no feedback for valid password', () => {
+    const result = validatePasswordStrength('Valid1!A');
+    assert.equal(result.score, 5);
+    assert.equal(result.feedback.length, 0);
+    assert.ok(result.isValid);
+  });
+
+  it('returns feedback and correct score for short password', () => {
+    const result = validatePasswordStrength('Ab1!');
+    assert.equal(result.score, 4);
+    assert.ok(result.feedback.includes('Password must be at least 8 characters long'));
+    assert.equal(result.isValid, false);
+  });
+
+  it('detects missing character types', () => {
+    const result = validatePasswordStrength('abcdefgh');
+    assert.equal(result.score, 2);
+    assert.ok(result.feedback.includes('Include at least one uppercase letter'));
+    assert.ok(result.feedback.includes('Include at least one number'));
+    assert.ok(result.feedback.includes('Include at least one special character'));
+    assert.equal(result.isValid, false);
+  });
+});

--- a/Downloads/cinematic-ai-chatbot(13)/package.json
+++ b/Downloads/cinematic-ai-chatbot(13)/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc -p tsconfig.test.json && node --test ./dist/__tests__/password-validation.test.js"
   },
   "dependencies": {
     "@ai-sdk/openai": "latest",

--- a/Downloads/cinematic-ai-chatbot(13)/tsconfig.test.json
+++ b/Downloads/cinematic-ai-chatbot(13)/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "module": "nodenext",
+    "target": "es2020",
+    "moduleResolution": "node16"
+  },
+  "include": [
+    "lib/utils/password-validation.ts",
+    "__tests__/password-validation.test.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create password validation tests
- configure TypeScript build for tests
- expose `npm test` script
- ignore `dist` build output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bd86a17048326b17adbef0dd440ba