### PR TITLE
Fix comment in graph stress tester

### DIFF
--- a/Downloads/cinematic-ai-chatbot(13)/components/graph/graph-stress-tester.tsx
+++ b/Downloads/cinematic-ai-chatbot(13)/components/graph/graph-stress-tester.tsx
@@ -20,7 +20,7 @@ export function GraphStressTester({ onDataGenerated, onReset }: StressTesterProp
   const [connectionDensity, setConnectionDensity] = useState([0.3])
   const [lastGenerated, setLastGenerated] = useState<{ nodes: number; links: number } | null>(null)
 
-  // Helper function as arrow function to avoid 'this' context issues
+  // Determine whether the target node is exactly one level below the source node
   const isHierarchicalConnection = (sourceType: string, targetType: string): boolean => {
     const hierarchy = ["initiative", "operation", "milestone", "task"]
     const sourceLevel = hierarchy.indexOf(sourceType)


### PR DESCRIPTION
## Summary
- clarify function purpose comment in `GraphStressTester`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd86426a88326ae6e60b21508648e