### PR TITLE
Fix toast effect cleanup

### DIFF
--- a/Downloads/cinematic-ai-chatbot(13)/components/ui/use-toast.ts
+++ b/Downloads/cinematic-ai-chatbot(13)/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/Downloads/cinematic-ai-chatbot(13)/hooks/use-toast.ts
+++ b/Downloads/cinematic-ai-chatbot(13)/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- add `useEffect` dependencies only once for toasts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd85c9b588326a0b4d40057cfbfa8