### PR TITLE
Fix toast timeout

### DIFF
--- a/Downloads/cinematic-ai-chatbot(13)/components/ui/use-toast.ts
+++ b/Downloads/cinematic-ai-chatbot(13)/components/ui/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string

--- a/Downloads/cinematic-ai-chatbot(13)/hooks/use-toast.ts
+++ b/Downloads/cinematic-ai-chatbot(13)/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten toast removal delay to 10 seconds

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd854cabc83269d21487c6b760bc9